### PR TITLE
feat: Product libraries module

### DIFF
--- a/src/app/(authenticated)/products/page.tsx
+++ b/src/app/(authenticated)/products/page.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { Plus, Search } from "lucide-react";
+import { prisma } from "@/lib/prisma";
+import { Button } from "@/components/ui/button";
+import { ProductFilters } from "@/components/products/product-filters";
+import { ProductTable } from "@/components/products/product-table";
+import { ProductAddButton } from "@/components/products/product-add-button";
+import {
+  LIBRARY_TYPES,
+  LIBRARY_TYPE_LABELS,
+  type LibraryType,
+} from "@/lib/validations/product";
+import type { ProductLibraryType } from "@/generated/prisma/client";
+
+interface ProductsPageProps {
+  searchParams: Promise<{
+    type?: string;
+    search?: string;
+    page?: string;
+    showInactive?: string;
+  }>;
+}
+
+export default async function ProductsPage({
+  searchParams,
+}: ProductsPageProps) {
+  const params = await searchParams;
+  const libraryType = (
+    LIBRARY_TYPES.includes(params.type as LibraryType)
+      ? params.type
+      : "VALVE"
+  ) as LibraryType;
+  const search = params.search ?? "";
+  const page = parseInt(params.page ?? "1", 10);
+  const pageSize = 50;
+  const showInactive = params.showInactive === "true";
+
+  const where = {
+    libraryType: libraryType as ProductLibraryType,
+    ...(showInactive ? {} : { isActive: true }),
+    ...(search
+      ? {
+          OR: [
+            { description: { contains: search, mode: "insensitive" as const } },
+            ...(isNaN(Number(search))
+              ? []
+              : [{ libraryNo: { equals: Number(search) } }]),
+          ],
+        }
+      : {}),
+  };
+
+  const [items, total] = await Promise.all([
+    prisma.productLibraryItem.findMany({
+      where,
+      orderBy: { libraryNo: "asc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.productLibraryItem.count({ where }),
+  ]);
+
+  const totalPages = Math.ceil(total / pageSize);
+
+  // Serialize Decimal fields to strings for client components
+  const serializedItems = items.map((item) => ({
+    ...item,
+    price1: item.price1?.toString() ?? null,
+    price2: item.price2?.toString() ?? null,
+    price3: item.price3?.toString() ?? null,
+    price7: item.price7?.toString() ?? null,
+    price8: item.price8?.toString() ?? null,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Product Libraries</h1>
+          <p className="mt-1 text-muted-foreground">
+            {LIBRARY_TYPE_LABELS[libraryType]} — {total} item
+            {total !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <ProductAddButton libraryType={libraryType} />
+      </div>
+
+      <ProductFilters
+        currentType={libraryType}
+        defaultSearch={search}
+        showInactive={showInactive}
+      />
+
+      <div className="rounded-md border">
+        <ProductTable libraryType={libraryType} items={serializedItems} />
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/products",
+                    query: {
+                      type: libraryType,
+                      ...(search ? { search } : {}),
+                      ...(showInactive ? { showInactive: "true" } : {}),
+                      page: String(page - 1),
+                    },
+                  }}
+                >
+                  Previous
+                </Link>
+              </Button>
+            )}
+            {page < totalPages && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/products",
+                    query: {
+                      type: libraryType,
+                      ...(search ? { search } : {}),
+                      ...(showInactive ? { showInactive: "true" } : {}),
+                      page: String(page + 1),
+                    },
+                  }}
+                >
+                  Next
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { productSchema } from "@/lib/validations/product";
+import type { ProductLibraryType } from "@/generated/prisma/client";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+  const result = productSchema.safeParse(body);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: result.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { libraryType, description, size, type, ...prices } = result.data;
+
+  const p1 = prices.price1 ? parseFloat(prices.price1) : null;
+  const p2 = prices.price2 ? parseFloat(prices.price2) : null;
+  const p7 = prices.price7 ? parseFloat(prices.price7) : null;
+  const p8 = prices.price8 ? parseFloat(prices.price8) : null;
+  const p3 = libraryType === "FITTING" && p1 != null
+    ? Math.round(p1 * 1.1 * 100) / 100
+    : prices.price3 ? parseFloat(prices.price3) : null;
+
+  const item = await prisma.productLibraryItem.update({
+    where: { id },
+    data: {
+      libraryType: libraryType as ProductLibraryType,
+      description,
+      size: size || null,
+      type: type || null,
+      price1: p1,
+      price2: p2,
+      price3: p3,
+      price7: p7,
+      price8: p8,
+    },
+  });
+
+  return NextResponse.json(item);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body = await request.json();
+
+  if (typeof body.isActive !== "boolean") {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const item = await prisma.productLibraryItem.update({
+    where: { id },
+    data: {
+      isActive: body.isActive,
+      ...(body.isActive ? {} : { deletedAt: new Date() }),
+    },
+  });
+
+  return NextResponse.json(item);
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { productSchema, LIBRARY_TYPES } from "@/lib/validations/product";
+import type { ProductLibraryType } from "@/generated/prisma/client";
+
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const type = searchParams.get("type") ?? "VALVE";
+  const search = searchParams.get("search") ?? "";
+  const page = parseInt(searchParams.get("page") ?? "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") ?? "50", 10);
+  const showInactive = searchParams.get("showInactive") === "true";
+
+  if (!LIBRARY_TYPES.includes(type as (typeof LIBRARY_TYPES)[number])) {
+    return NextResponse.json({ error: "Invalid library type" }, { status: 400 });
+  }
+
+  const where = {
+    libraryType: type as ProductLibraryType,
+    ...(showInactive ? {} : { isActive: true }),
+    ...(search
+      ? {
+          OR: [
+            { description: { contains: search, mode: "insensitive" as const } },
+            ...(isNaN(Number(search))
+              ? []
+              : [{ libraryNo: { equals: Number(search) } }]),
+          ],
+        }
+      : {}),
+  };
+
+  const [items, total] = await Promise.all([
+    prisma.productLibraryItem.findMany({
+      where,
+      orderBy: { libraryNo: "asc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.productLibraryItem.count({ where }),
+  ]);
+
+  return NextResponse.json({ items, total, page, pageSize });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const result = productSchema.safeParse(body);
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: result.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { libraryType, description, size, type, ...prices } = result.data;
+
+  // Parse prices to numbers
+  const p1 = prices.price1 ? parseFloat(prices.price1) : null;
+  const p2 = prices.price2 ? parseFloat(prices.price2) : null;
+  const p7 = prices.price7 ? parseFloat(prices.price7) : null;
+  const p8 = prices.price8 ? parseFloat(prices.price8) : null;
+  // Auto-calculate price3 for fittings
+  const p3 = libraryType === "FITTING" && p1 != null
+    ? Math.round(p1 * 1.1 * 100) / 100
+    : prices.price3 ? parseFloat(prices.price3) : null;
+
+  // Get the next libraryNo for this type
+  const maxItem = await prisma.productLibraryItem.findFirst({
+    where: { libraryType: libraryType as ProductLibraryType },
+    orderBy: { libraryNo: "desc" },
+    select: { libraryNo: true },
+  });
+  const nextLibraryNo = (maxItem?.libraryNo ?? 0) + 1;
+
+  const item = await prisma.productLibraryItem.create({
+    data: {
+      libraryType: libraryType as ProductLibraryType,
+      libraryNo: nextLibraryNo,
+      description,
+      size: size || null,
+      type: type || null,
+      price1: p1,
+      price2: p2,
+      price3: p3,
+      price7: p7,
+      price8: p8,
+    },
+  });
+
+  return NextResponse.json(item, { status: 201 });
+}

--- a/src/components/products/product-add-button.tsx
+++ b/src/components/products/product-add-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ProductDialog } from "./product-dialog";
+import type { LibraryType } from "@/lib/validations/product";
+
+interface ProductAddButtonProps {
+  libraryType: LibraryType;
+}
+
+export function ProductAddButton({ libraryType }: ProductAddButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <Plus className="mr-2 h-4 w-4" />
+        Add Item
+      </Button>
+
+      <ProductDialog
+        libraryType={libraryType}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}

--- a/src/components/products/product-dialog.tsx
+++ b/src/components/products/product-dialog.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import {
+  productSchema,
+  type ProductFormValues,
+  type LibraryType,
+  PRICING_FIELDS,
+  PRICE_LABELS,
+} from "@/lib/validations/product";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+interface ProductDialogProps {
+  libraryType: LibraryType;
+  product?: {
+    id: string;
+    description: string;
+    size: string | null;
+    type: string | null;
+    price1: string | number | null;
+    price2: string | number | null;
+    price3: string | number | null;
+    price7: string | number | null;
+    price8: string | number | null;
+  };
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function toStr(v: string | number | null | undefined): string {
+  if (v == null) return "";
+  return String(v);
+}
+
+export function ProductDialog({
+  libraryType,
+  product,
+  open,
+  onOpenChange,
+}: ProductDialogProps) {
+  const router = useRouter();
+  const [error, setError] = useState("");
+  const isEdit = !!product;
+
+  const pricingFields = PRICING_FIELDS[libraryType];
+
+  const form = useForm<ProductFormValues>({
+    resolver: zodResolver(productSchema),
+    defaultValues: product
+      ? {
+          libraryType,
+          description: product.description,
+          size: product.size ?? "",
+          type: product.type ?? "",
+          price1: toStr(product.price1),
+          price2: toStr(product.price2),
+          price3: toStr(product.price3),
+          price7: toStr(product.price7),
+          price8: toStr(product.price8),
+        }
+      : {
+          libraryType,
+          description: "",
+          size: "",
+          type: "",
+          price1: "",
+          price2: "",
+          price3: "",
+          price7: "",
+          price8: "",
+        },
+  });
+
+  async function onSubmit(data: ProductFormValues) {
+    setError("");
+
+    const url = isEdit ? `/api/products/${product.id}` : "/api/products";
+    const method = isEdit ? "PUT" : "POST";
+
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    if (!res.ok) {
+      const body = await res.json();
+      setError(body.error ?? "Something went wrong");
+      return;
+    }
+
+    toast.success(isEdit ? "Item updated" : "Item added");
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? "Edit Library Item" : "Add Library Item"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            {error && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description *</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="size"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Size</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Type</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              {pricingFields.map((field) => {
+                const isCalculated =
+                  field === "price3" && libraryType === "FITTING";
+
+                return (
+                  <FormField
+                    key={field}
+                    control={form.control}
+                    name={field as keyof ProductFormValues}
+                    render={({ field: f }) => (
+                      <FormItem>
+                        <FormLabel>{PRICE_LABELS[field]}</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            step="0.01"
+                            placeholder="0.00"
+                            disabled={isCalculated}
+                            {...f}
+                            value={f.value as string}
+                          />
+                        </FormControl>
+                        {isCalculated && (
+                          <p className="text-xs text-muted-foreground">
+                            Auto-calculated: Base Price x 1.1
+                          </p>
+                        )}
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                );
+              })}
+            </div>
+
+            <div className="flex gap-3 justify-end">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={form.formState.isSubmitting}>
+                {form.formState.isSubmitting
+                  ? "Saving..."
+                  : isEdit
+                    ? "Save"
+                    : "Add Item"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/products/product-filters.tsx
+++ b/src/components/products/product-filters.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  LIBRARY_TYPES,
+  LIBRARY_TYPE_LABELS,
+  type LibraryType,
+} from "@/lib/validations/product";
+
+interface ProductFiltersProps {
+  currentType: LibraryType;
+  defaultSearch: string;
+  showInactive: boolean;
+}
+
+export function ProductFilters({
+  currentType,
+  defaultSearch,
+  showInactive,
+}: ProductFiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [search, setSearch] = useState(defaultSearch);
+
+  function navigate(overrides: Record<string, string | undefined>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, val] of Object.entries(overrides)) {
+      if (val) {
+        params.set(key, val);
+      } else {
+        params.delete(key);
+      }
+    }
+    params.delete("page");
+    startTransition(() => {
+      router.push(`/products?${params.toString()}`);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Library type pills */}
+      <div className="flex flex-wrap gap-1">
+        {LIBRARY_TYPES.map((t) => (
+          <button
+            key={t}
+            onClick={() => navigate({ type: t, search: undefined })}
+            className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+              currentType === t
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            } ${isPending ? "opacity-50" : ""}`}
+          >
+            {LIBRARY_TYPE_LABELS[t]}
+          </button>
+        ))}
+      </div>
+
+      {/* Search and filters */}
+      <div className="flex items-center gap-4">
+        <div className="relative flex-1 max-w-sm">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by description or lib #..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              navigate({ search: e.target.value || undefined });
+            }}
+            className={`pl-8 ${isPending ? "opacity-50" : ""}`}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="showInactive"
+            checked={showInactive}
+            onChange={(e) =>
+              navigate({
+                showInactive: e.target.checked ? "true" : undefined,
+              })
+            }
+            className="rounded border-input"
+          />
+          <Label htmlFor="showInactive" className="text-sm cursor-pointer">
+            Show inactive
+          </Label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/products/product-table.tsx
+++ b/src/components/products/product-table.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Pencil, Ban, RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ProductDialog } from "./product-dialog";
+import {
+  type LibraryType,
+  PRICING_FIELDS,
+  PRICE_LABELS,
+} from "@/lib/validations/product";
+
+interface ProductItem {
+  id: string;
+  libraryNo: number;
+  description: string;
+  size: string | null;
+  type: string | null;
+  price1: string | number | null;
+  price2: string | number | null;
+  price3: string | number | null;
+  price7: string | number | null;
+  price8: string | number | null;
+  isActive: boolean;
+}
+
+interface ProductTableProps {
+  libraryType: LibraryType;
+  items: ProductItem[];
+}
+
+function formatPrice(value: string | number | null): string {
+  if (value == null) return "—";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  if (isNaN(num)) return "—";
+  return `$${num.toFixed(2)}`;
+}
+
+export function ProductTable({ libraryType, items }: ProductTableProps) {
+  const router = useRouter();
+  const [editItem, setEditItem] = useState<ProductItem | undefined>();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const pricingFields = PRICING_FIELDS[libraryType];
+
+  async function toggleActive(item: ProductItem) {
+    const action = item.isActive ? "deactivate" : "reactivate";
+    if (!confirm(`Are you sure you want to ${action} this item?`)) return;
+
+    const res = await fetch(`/api/products/${item.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isActive: !item.isActive }),
+    });
+
+    if (res.ok) {
+      toast.success(`Item ${action}d`);
+      router.refresh();
+    }
+  }
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-20">Lib #</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead>Size</TableHead>
+            <TableHead>Type</TableHead>
+            {pricingFields.map((f) => (
+              <TableHead key={f} className="text-right">
+                {PRICE_LABELS[f]}
+              </TableHead>
+            ))}
+            <TableHead className="w-20">Status</TableHead>
+            <TableHead className="w-24"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {items.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={5 + pricingFields.length + 1}
+                className="h-24 text-center text-muted-foreground"
+              >
+                No items in this library.
+              </TableCell>
+            </TableRow>
+          ) : (
+            items.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell className="font-mono">{item.libraryNo}</TableCell>
+                <TableCell className="font-medium">{item.description}</TableCell>
+                <TableCell>{item.size}</TableCell>
+                <TableCell>{item.type}</TableCell>
+                {pricingFields.map((f) => (
+                  <TableCell key={f} className="text-right font-mono">
+                    {formatPrice(item[f as keyof ProductItem] as string | number | null)}
+                  </TableCell>
+                ))}
+                <TableCell>
+                  <Badge variant={item.isActive ? "default" : "secondary"}>
+                    {item.isActive ? "Active" : "Inactive"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => {
+                        setEditItem(item);
+                        setDialogOpen(true);
+                      }}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      onClick={() => toggleActive(item)}
+                    >
+                      {item.isActive ? (
+                        <Ban className="h-3.5 w-3.5 text-destructive" />
+                      ) : (
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      <ProductDialog
+        libraryType={libraryType}
+        product={editItem}
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setEditItem(undefined);
+        }}
+      />
+    </>
+  );
+}

--- a/src/lib/validations/product.ts
+++ b/src/lib/validations/product.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+export const LIBRARY_TYPES = [
+  "VALVE",
+  "VALVE1",
+  "VALVE2",
+  "WELL_VALVE",
+  "FITTING",
+  "PUP",
+  "WELL_COMPONENT",
+  "ACCESSORY",
+] as const;
+
+export type LibraryType = (typeof LIBRARY_TYPES)[number];
+
+export const LIBRARY_TYPE_LABELS: Record<LibraryType, string> = {
+  VALVE: "Valve",
+  VALVE1: "Valve 1",
+  VALVE2: "Valve 2",
+  WELL_VALVE: "Well Valve",
+  FITTING: "Fitting",
+  PUP: "PUP",
+  WELL_COMPONENT: "Well Component",
+  ACCESSORY: "Accessory",
+};
+
+/** Which pricing fields are relevant per library type */
+export const PRICING_FIELDS: Record<LibraryType, string[]> = {
+  VALVE: ["price7", "price8"],
+  VALVE1: ["price7", "price8"],
+  VALVE2: ["price7", "price8"],
+  WELL_VALVE: ["price7", "price8"],
+  FITTING: ["price1", "price2", "price3"],
+  PUP: ["price1", "price2"],
+  WELL_COMPONENT: ["price1", "price2"],
+  ACCESSORY: ["price1", "price2"],
+};
+
+export const PRICE_LABELS: Record<string, string> = {
+  price1: "Base Price",
+  price2: "Tier 2",
+  price3: "Tier 3 (Calculated)",
+  price7: "Standard",
+  price8: "Premium",
+};
+
+export const productSchema = z.object({
+  libraryType: z.enum(LIBRARY_TYPES),
+  description: z.string().min(1, "Description is required").max(500),
+  size: z.string().max(100).optional().or(z.literal("")),
+  type: z.string().max(100).optional().or(z.literal("")),
+  price1: z.string().optional().or(z.literal("")),
+  price2: z.string().optional().or(z.literal("")),
+  price3: z.string().optional().or(z.literal("")),
+  price7: z.string().optional().or(z.literal("")),
+  price8: z.string().optional().or(z.literal("")),
+});
+
+export type ProductFormValues = z.infer<typeof productSchema>;


### PR DESCRIPTION
## Summary
- Single `/products` page with pill-tab selector for all 8 library types (Valve, Valve 1, Valve 2, Well Valve, Fitting, PUP, Well Component, Accessory)
- Data table with type-specific pricing columns (price7/price8 for valves, price1/price2/price3 for fittings, etc.)
- Add/edit dialog with dynamic pricing fields based on selected library type
- Auto-calculates fitting Tier 3 price (base price x 1.1) on every save
- Search by description or library number, pagination, active/inactive filter
- Soft delete via isActive toggle with confirm dialog

Closes #7

## Test plan
- [ ] Switch between library types using pill tabs
- [ ] Verify correct pricing columns display per type
- [ ] Add a new library item and verify it gets the next library number
- [ ] Edit an existing item's pricing
- [ ] Add a fitting item and verify price3 auto-calculates
- [ ] Deactivate/reactivate an item
- [ ] Search by description and library number

🤖 Generated with [Claude Code](https://claude.com/claude-code)