### PR TITLE
feat: shipping queue page with ship dialog (#27)

### DIFF
--- a/prisma/migrations/20260216215627_add_shipping_fields/migration.sql
+++ b/prisma/migrations/20260216215627_add_shipping_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "orders" ADD COLUMN     "carrierName" TEXT,
+ADD COLUMN     "trackingNumber" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -292,6 +292,8 @@ model Order {
   isComplete      Boolean     @default(false)
   percentComplete Int         @default(0)
   shipToAddressId String?
+  carrierName     String?
+  trackingNumber  String?
   sourceQuoteId   String?
   legacyOrderNo   Int?
 

--- a/src/app/(authenticated)/shipping/page.tsx
+++ b/src/app/(authenticated)/shipping/page.tsx
@@ -1,0 +1,55 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { hasPermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { ShippingOrderList } from "@/components/shipping/shipping-order-list";
+
+export default async function ShippingPage() {
+  const session = await auth();
+  if (!session) redirect("/login");
+
+  const allowed = await hasPermission(session.user.id, "shipping");
+  if (!allowed) redirect("/");
+
+  const orders = await prisma.order.findMany({
+    where: {
+      status: "READY_TO_SHIP",
+    },
+    include: {
+      customer: { select: { id: true, company: true } },
+      details: { select: { quantity: true } },
+      shipToAddress: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const serialized = orders.map((order) => ({
+    id: order.id,
+    orderNo: order.orderNo,
+    customerName: order.customer.company,
+    customerId: order.customer.id,
+    poNumber: order.poNumber,
+    itemCount: order.details.reduce((sum, d) => sum + d.quantity, 0),
+    orderDate: order.orderDate.toISOString(),
+    shipToAddress: order.shipToAddress
+      ? {
+          id: order.shipToAddress.id,
+          name: order.shipToAddress.name,
+          city: order.shipToAddress.city,
+        }
+      : null,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Shipping Queue</h1>
+        <p className="mt-1 text-muted-foreground">
+          {serialized.length} order{serialized.length !== 1 ? "s" : ""} ready to
+          ship
+        </p>
+      </div>
+      <ShippingOrderList orders={serialized} />
+    </div>
+  );
+}

--- a/src/app/api/shop/orders/[id]/ship/route.test.ts
+++ b/src/app/api/shop/orders/[id]/ship/route.test.ts
@@ -25,6 +25,11 @@ function makeRequest(body: unknown) {
 
 const paramsPromise = Promise.resolve({ id: "order-1" });
 
+const validShipBody = {
+  shipToAddressId: "addr-1",
+  carrierName: "FedEx",
+};
+
 describe("PATCH /api/shop/orders/[id]/ship", () => {
   beforeEach(() => {
     mockHasPermission.mockResolvedValue(true);
@@ -40,7 +45,7 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
     expect(body.error).toBe("Unauthorized");
   });
 
-  it("returns 403 when user lacks SHOP_SHIP permission", async () => {
+  it("returns 403 when user lacks shipping permission", async () => {
     mockHasPermission.mockResolvedValueOnce(false);
 
     const res = await PATCH(makeRequest({}), { params: paramsPromise });
@@ -50,7 +55,7 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
     expect(body.error).toBe("Forbidden");
     expect(mockHasPermission).toHaveBeenCalledWith(
       "test-user-id",
-      "SHOP_SHIP"
+      "shipping"
     );
   });
 
@@ -77,6 +82,23 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
     expect(body.error).toBe("Only orders ready to ship can be shipped");
   });
 
+  it("returns 400 for validation failure (missing required fields)", async () => {
+    mockPrisma.order.findUnique.mockResolvedValueOnce({
+      id: "order-1",
+      status: "READY_TO_SHIP",
+    } as never);
+
+    const res = await PATCH(
+      makeRequest({}),
+      { params: paramsPromise }
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.issues).toBeDefined();
+  });
+
   it("returns 400 for validation failure (notes too long)", async () => {
     mockPrisma.order.findUnique.mockResolvedValueOnce({
       id: "order-1",
@@ -84,7 +106,7 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
     } as never);
 
     const res = await PATCH(
-      makeRequest({ notes: "x".repeat(501) }),
+      makeRequest({ ...validShipBody, notes: "x".repeat(501) }),
       { params: paramsPromise }
     );
 
@@ -114,7 +136,7 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
       notes: null,
     } as never);
 
-    const res = await PATCH(makeRequest({}), { params: paramsPromise });
+    const res = await PATCH(makeRequest(validShipBody), { params: paramsPromise });
 
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -130,6 +152,9 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
         data: expect.objectContaining({
           status: "SHIPPED",
           shipDate: expect.any(Date),
+          shipToAddressId: "addr-1",
+          carrierName: "FedEx",
+          trackingNumber: null,
         }),
       })
     );
@@ -170,7 +195,7 @@ describe("PATCH /api/shop/orders/[id]/ship", () => {
     } as never);
 
     const res = await PATCH(
-      makeRequest({ notes: "Shipped via FedEx tracking #12345" }),
+      makeRequest({ ...validShipBody, notes: "Shipped via FedEx tracking #12345" }),
       { params: paramsPromise }
     );
 

--- a/src/app/api/shop/orders/[id]/ship/route.ts
+++ b/src/app/api/shop/orders/[id]/ship/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const allowed = await hasPermission(session.user.id, "SHOP_SHIP");
+  const allowed = await hasPermission(session.user.id, "shipping");
   if (!allowed) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
@@ -51,6 +51,9 @@ export async function PATCH(
     data: {
       status: "SHIPPED",
       shipDate: new Date(),
+      shipToAddressId: result.data.shipToAddressId,
+      carrierName: result.data.carrierName,
+      trackingNumber: result.data.trackingNumber || null,
     },
   });
 

--- a/src/components/shipping/ship-dialog.tsx
+++ b/src/components/shipping/ship-dialog.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, Truck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ShippingOrder } from "./shipping-order-list";
+
+interface CarrierData {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+interface ShipToData {
+  id: string;
+  name: string;
+  city: string;
+  address1: string;
+  isDefault: boolean;
+}
+
+interface ShipDialogProps {
+  order: ShippingOrder;
+}
+
+export function ShipDialog({ order }: ShipDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [carriers, setCarriers] = useState<CarrierData[]>([]);
+  const [shipToAddresses, setShipToAddresses] = useState<ShipToData[]>([]);
+
+  const [shipToAddressId, setShipToAddressId] = useState("");
+  const [carrierName, setCarrierName] = useState("");
+  const [trackingNumber, setTrackingNumber] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const fetchCustomerData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/customers/${order.customerId}`);
+      if (!res.ok) {
+        setError("Failed to load customer data");
+        return;
+      }
+      const data = await res.json();
+
+      const customerCarriers: CarrierData[] = data.carriers || [];
+      const customerAddresses: ShipToData[] = data.shipToAddresses || [];
+
+      setCarriers(customerCarriers);
+      setShipToAddresses(customerAddresses);
+
+      // Pre-select defaults
+      const defaultAddress =
+        customerAddresses.find((a: ShipToData) => a.isDefault) ||
+        customerAddresses.find(
+          (a: ShipToData) => a.id === order.shipToAddress?.id
+        );
+      if (defaultAddress) {
+        setShipToAddressId(defaultAddress.id);
+      }
+
+      const defaultCarrier = customerCarriers.find(
+        (c: CarrierData) => c.isDefault
+      );
+      if (defaultCarrier) {
+        setCarrierName(defaultCarrier.name);
+      }
+    } catch {
+      setError("Failed to load customer data");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [order.customerId, order.shipToAddress?.id]);
+
+  useEffect(() => {
+    if (open) {
+      fetchCustomerData();
+    }
+  }, [open, fetchCustomerData]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!shipToAddressId || !carrierName) return;
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/shop/orders/${order.id}/ship`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          shipToAddressId,
+          carrierName,
+          trackingNumber: trackingNumber || undefined,
+          notes: notes || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to ship order");
+        return;
+      }
+
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError("Failed to ship order");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (!value) {
+      setShipToAddressId("");
+      setCarrierName("");
+      setTrackingNumber("");
+      setNotes("");
+      setError(null);
+      setCarriers([]);
+      setShipToAddresses([]);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Truck className="mr-1 h-3 w-3" />
+          Ship
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>Ship Order #{order.orderNo}</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="rounded-md border px-3 py-2">
+              <p className="text-xs text-muted-foreground">Customer</p>
+              <p className="font-medium">{order.customerName}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="shipTo">Ship-To Address</Label>
+              {shipToAddresses.length > 0 ? (
+                <Select
+                  value={shipToAddressId}
+                  onValueChange={setShipToAddressId}
+                >
+                  <SelectTrigger id="shipTo">
+                    <SelectValue placeholder="Select ship-to address" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {shipToAddresses.map((addr) => (
+                      <SelectItem key={addr.id} value={addr.id}>
+                        {addr.name} — {addr.city}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No ship-to addresses on file for this customer.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="carrier">Carrier</Label>
+              {carriers.length > 0 ? (
+                <Select value={carrierName} onValueChange={setCarrierName}>
+                  <SelectTrigger id="carrier">
+                    <SelectValue placeholder="Select carrier" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {carriers.map((carrier) => (
+                      <SelectItem key={carrier.id} value={carrier.name}>
+                        {carrier.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Input
+                  id="carrier"
+                  placeholder="Enter carrier name..."
+                  value={carrierName}
+                  onChange={(e) => setCarrierName(e.target.value)}
+                />
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="tracking">Tracking Number</Label>
+              <Input
+                id="tracking"
+                placeholder="Enter tracking number (optional)"
+                value={trackingNumber}
+                onChange={(e) => setTrackingNumber(e.target.value)}
+                maxLength={100}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea
+                id="notes"
+                placeholder="Shipping notes (optional)"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                maxLength={500}
+                rows={3}
+              />
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive">{error}</p>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isSubmitting || !shipToAddressId || !carrierName}
+            >
+              {isSubmitting && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Confirm Shipment
+            </Button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/shipping/shipping-order-list.tsx
+++ b/src/components/shipping/shipping-order-list.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ShipDialog } from "./ship-dialog";
+
+interface ShipToAddress {
+  id: string;
+  name: string;
+  city: string;
+}
+
+export interface ShippingOrder {
+  id: string;
+  orderNo: number;
+  customerName: string;
+  customerId: string;
+  poNumber: string | null;
+  itemCount: number;
+  orderDate: string;
+  shipToAddress: ShipToAddress | null;
+}
+
+interface ShippingOrderListProps {
+  orders: ShippingOrder[];
+}
+
+export function ShippingOrderList({ orders }: ShippingOrderListProps) {
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search) return orders;
+
+    const term = search.toLowerCase();
+    return orders.filter((order) => {
+      const matchesOrderNo = String(order.orderNo)
+        .toLowerCase()
+        .includes(term);
+      const matchesCustomer = order.customerName
+        .toLowerCase()
+        .includes(term);
+      const matchesPO = order.poNumber
+        ? order.poNumber.toLowerCase().includes(term)
+        : false;
+
+      return matchesOrderNo || matchesCustomer || matchesPO;
+    });
+  }, [orders, search]);
+
+  return (
+    <div className="space-y-4">
+      <div className="relative max-w-sm">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search by order #, customer, or PO..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-8"
+        />
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-24">Order #</TableHead>
+              <TableHead>Customer</TableHead>
+              <TableHead className="w-28">PO #</TableHead>
+              <TableHead className="w-20">Items</TableHead>
+              <TableHead className="w-28">Order Date</TableHead>
+              <TableHead>Ship-To</TableHead>
+              <TableHead className="w-24">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="h-24 text-center">
+                  {search ? (
+                    <div className="flex flex-col items-center gap-1">
+                      <Search className="h-8 w-8 text-muted-foreground" />
+                      <p className="text-muted-foreground">
+                        No orders found
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-muted-foreground">
+                      No orders ready to ship.
+                    </p>
+                  )}
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((order) => (
+                <TableRow key={order.id}>
+                  <TableCell className="font-mono font-medium">
+                    {order.orderNo}
+                  </TableCell>
+                  <TableCell>{order.customerName}</TableCell>
+                  <TableCell>{order.poNumber || "\u2014"}</TableCell>
+                  <TableCell>{order.itemCount}</TableCell>
+                  <TableCell>
+                    {new Date(order.orderDate).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>
+                    {order.shipToAddress
+                      ? `${order.shipToAddress.name}, ${order.shipToAddress.city}`
+                      : "\u2014"}
+                  </TableCell>
+                  <TableCell>
+                    <ShipDialog order={order} />
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/validations/shop.test.ts
+++ b/src/lib/validations/shop.test.ts
@@ -128,20 +128,66 @@ describe("processStepSchema", () => {
 });
 
 describe("shipOrderSchema", () => {
-  it("accepts empty object", () => {
-    const result = shipOrderSchema.safeParse({});
+  const validData = {
+    shipToAddressId: "addr-1",
+    carrierName: "FedEx",
+  };
+
+  it("accepts valid required fields", () => {
+    const result = shipOrderSchema.safeParse(validData);
     expect(result.success).toBe(true);
   });
 
-  it("accepts valid notes", () => {
+  it("accepts all fields", () => {
     const result = shipOrderSchema.safeParse({
-      notes: "Shipped via FedEx tracking #12345",
+      ...validData,
+      trackingNumber: "1Z999AA10123456784",
+      notes: "Handle with care",
     });
     expect(result.success).toBe(true);
   });
 
+  it("rejects missing shipToAddressId", () => {
+    const result = shipOrderSchema.safeParse({
+      carrierName: "FedEx",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty shipToAddressId", () => {
+    const result = shipOrderSchema.safeParse({
+      ...validData,
+      shipToAddressId: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing carrierName", () => {
+    const result = shipOrderSchema.safeParse({
+      shipToAddressId: "addr-1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty carrierName", () => {
+    const result = shipOrderSchema.safeParse({
+      ...validData,
+      carrierName: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects trackingNumber exceeding 100 chars", () => {
+    const result = shipOrderSchema.safeParse({
+      ...validData,
+      trackingNumber: "A".repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects notes exceeding 500 chars", () => {
     const result = shipOrderSchema.safeParse({
+      ...validData,
       notes: "A".repeat(501),
     });
     expect(result.success).toBe(false);
@@ -149,13 +195,18 @@ describe("shipOrderSchema", () => {
 
   it("accepts notes at exactly 500 chars", () => {
     const result = shipOrderSchema.safeParse({
+      ...validData,
       notes: "A".repeat(500),
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts undefined notes", () => {
-    const result = shipOrderSchema.safeParse({ notes: undefined });
+  it("accepts undefined optional fields", () => {
+    const result = shipOrderSchema.safeParse({
+      ...validData,
+      trackingNumber: undefined,
+      notes: undefined,
+    });
     expect(result.success).toBe(true);
   });
 });

--- a/src/lib/validations/shop.ts
+++ b/src/lib/validations/shop.ts
@@ -22,6 +22,9 @@ export const processStepSchema = z.object({
 export type ProcessStepInput = z.infer<typeof processStepSchema>;
 
 export const shipOrderSchema = z.object({
+  shipToAddressId: z.string().min(1, "Ship-to address is required"),
+  carrierName: z.string().min(1, "Carrier is required"),
+  trackingNumber: z.string().max(100).optional(),
   notes: z.string().max(500).optional(),
 });
 


### PR DESCRIPTION
## Summary
- **Shipping queue page** at `/shipping` listing orders with `READY_TO_SHIP` status, with search by order #, customer, or PO
- **Ship dialog** with carrier selection (from customer's carriers), ship-to address picker, tracking number, and notes
- **Schema migration** adding `carrierName` and `trackingNumber` fields to Order model
- **Updated ship API** to save carrier, tracking, and ship-to address; fixed permission code (`SHOP_SHIP` → `shipping`)
- Updated validation schema and all related tests (796 passing, +6 net new)

Closes #27

## Test plan
- [ ] Navigate to `/shipping` — page loads, shows READY_TO_SHIP orders
- [ ] Search filters work (order #, customer, PO)
- [ ] Click "Ship" → dialog opens with carrier/address dropdowns populated from customer data
- [ ] Submit ship dialog → order moves to SHIPPED, disappears from queue
- [ ] `npm test` — 796 tests pass
- [ ] `npx next build` — builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)